### PR TITLE
(dev): Automate setting of "mode" for candidate app based on env

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "lerna run build",
     "lint": "lerna exec -- eslint . --ext .js,.jsx,.ts,.tsx",
     "start-candidate-app": "cd packages/examsecure-candidate-app && node scripts/start.js",
+    "start-candidate-app-with-api-calls": "cd packages/examsecure-candidate-app && set \"REACT_APP_TURN_ON_API_CALLS=1\" && node scripts/start.js",
     "build-candidate-app": "cd packages/examsecure-candidate-app && node scripts/build.js",
     "start-educator-app": "cd packages/examsecure-educator-app && node scripts/start.js",
     "build-educator-app": "cd packages/examsecure-educator-app && node scripts/build.js",

--- a/packages/examsecure-candidate-app/package.json
+++ b/packages/examsecure-candidate-app/package.json
@@ -82,7 +82,7 @@
   "scripts": {
     "start": "SET HTTPS=true && node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "jest",
+    "test": "set \"REACT_APP_TURN_ON_API_CALLS=1\" && jest",
     "deploy": "npm run build && firebase deploy"
   },
   "browserslist": [

--- a/packages/examsecure-candidate-app/src/components/helpers/modeSetter.js
+++ b/packages/examsecure-candidate-app/src/components/helpers/modeSetter.js
@@ -1,4 +1,11 @@
 // Temporary hack to easily disable calls to AWS Lambda and Rekognition for testing purposes without incurring charges
-// TODO: Clean up and change it to use environment vars
+let mode = 0;
 
-export const mode = 1;
+if (
+  process.env.NODE_ENV === 'production' ||
+  process.env.REACT_APP_TURN_ON_API_CALLS === '1'
+) {
+  mode = 1;
+}
+
+export { mode };


### PR DESCRIPTION
The `mode` variable in candidate-app controls whether api calls are sent. mode = 0 is helpful while development to avoid unnecessary charges